### PR TITLE
compatible with loadUrl "javascript:"

### DIFF
--- a/dsbridge/src/main/java/wendu/dsbridge/DWebView.java
+++ b/dsbridge/src/main/java/wendu/dsbridge/DWebView.java
@@ -421,8 +421,12 @@ public class DWebView extends WebView {
         runOnMainThread(new Runnable() {
             @Override
             public void run() {
-                callInfoList = new ArrayList<>();
-                DWebView.super.loadUrl(url);
+                if (url != null && url.startsWith("javascript:")){
+                    DWebView.super.loadUrl(url);
+                }else{
+                    callInfoList = new ArrayList<>();
+                    DWebView.super.loadUrl(url);
+                }
             }
         });
     }
@@ -439,8 +443,12 @@ public class DWebView extends WebView {
         runOnMainThread(new Runnable() {
             @Override
             public void run() {
-                callInfoList = new ArrayList<>();
-                DWebView.super.loadUrl(url, additionalHttpHeaders);
+                if (url != null && url.startsWith("javascript:")){
+                    DWebView.super.loadUrl(url, additionalHttpHeaders);
+                }else{
+                    callInfoList = new ArrayList<>();
+                    DWebView.super.loadUrl(url, additionalHttpHeaders);
+                }
             }
         });
     }


### PR DESCRIPTION
Many developer (app developer and sdk developer) call js function by invoke loadUrl("javascript:xxxx"), DSBridge should compatible with that